### PR TITLE
Integrate Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,16 +12,6 @@ matrix:
         - mysql
       before_script:
         - wget https://swift.org/builds/swift-4.2.2-release/ubuntu1604/swift-4.2.2-RELEASE/swift-4.2.2-RELEASE-ubuntu16.04.tar.gz
-        - wget https://swift.org/builds/swift-4.2.2-release/ubuntu1604/swift-4.2.2-RELEASE/swift-4.2.2-RELEASE-ubuntu16.04.tar.gz.sig
-        - gpg --keyserver hkp://pool.sks-keyservers.net
-          --recv-keys
-          '7463 A81A 4B2E EA1B 551F  FBCF D441 C977 412B 37AD'
-          '1BE1 E29A 084C B305 F397  D62A 9F59 7F4D 21A5 6D5F'
-          'A3BA FD35 56A5 9079 C068  94BD 63BC 1CFE 91D3 06C6'
-          '5E4D F843 FB06 5D7F 7E24  FBA2 EF54 30F0 71E1 B235'
-          '8513 444E 2DA3 6B7C 1659  AF4D 7638 F1FB 2B2B 08C4'
-        - gpg --keyserver hkp://pool.sks-keyservers.net --refresh-keys Swift
-        - gpg --verify swift-4.2.2-RELEASE-ubuntu16.04.tar.gz.sig
         - tar xzf swift-4.2.2-RELEASE-ubuntu16.04.tar.gz
         - export PATH=$(pwd)/swift-4.2.2-RELEASE-ubuntu16.04/usr/bin:"${PATH}"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,15 +12,6 @@ matrix:
         - mysql
       before_script:
         - wget https://swift.org/builds/swift-4.2.2-release/ubuntu1604/swift-4.2.2-RELEASE/swift-4.2.2-RELEASE-ubuntu16.04.tar.gz
-        - gpg --keyserver hkp://pool.sks-keyservers.net
-          --recv-keys
-          '7463 A81A 4B2E EA1B 551F  FBCF D441 C977 412B 37AD'
-          '1BE1 E29A 084C B305 F397  D62A 9F59 7F4D 21A5 6D5F'
-          'A3BA FD35 56A5 9079 C068  94BD 63BC 1CFE 91D3 06C6'
-          '5E4D F843 FB06 5D7F 7E24  FBA2 EF54 30F0 71E1 B235'
-          '8513 444E 2DA3 6B7C 1659  AF4D 7638 F1FB 2B2B 08C4'
-        - gpg --keyserver hkp://pool.sks-keyservers.net --refresh-keys Swift
-        - gpg --verify swift-4.2.2-RELEASE-ubuntu16.04.tar.gz
         - tar xzf swift-4.2.2-RELEASE-ubuntu16.04.tar.gz
         - export PATH=$(pwd)/swift-4.2.2-RELEASE-ubuntu16.04/usr/bin:"${PATH}"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,3 @@
-os:
-  - linux
-  - osx
-
 sudo:
   - false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,21 @@
-sudo: false
-language: swift
+os:
+  - linux
+  - osx
+
+sudo:
+  - false
+
+language:
+  - swift
 
 matrix:
   include:
-    - os: osx
+    - name: "OS X"
+      os: osx
       osx_image: xcode10.1
 
-    - os: linux
+    - name: "Linux"
+      os: linux
       dist: xenial
       services:
         - mysql

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,17 @@
 sudo:
   - false
 
-language:
-  - swift
-
 matrix:
   include:
     - name: "OS X"
       os: osx
       osx_image: xcode10.1
+      language: swift
 
     - name: "Linux"
       os: linux
       dist: xenial
+      language: c
       services:
         - mysql
       before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,16 @@ matrix:
         - mysql
       before_script:
         - wget https://swift.org/builds/swift-4.2.2-release/ubuntu1604/swift-4.2.2-RELEASE/swift-4.2.2-RELEASE-ubuntu16.04.tar.gz
+        - wget https://swift.org/builds/swift-4.2.2-release/ubuntu1604/swift-4.2.2-RELEASE/swift-4.2.2-RELEASE-ubuntu16.04.tar.gz.sig
+        - gpg --keyserver hkp://pool.sks-keyservers.net
+          --recv-keys
+          '7463 A81A 4B2E EA1B 551F  FBCF D441 C977 412B 37AD'
+          '1BE1 E29A 084C B305 F397  D62A 9F59 7F4D 21A5 6D5F'
+          'A3BA FD35 56A5 9079 C068  94BD 63BC 1CFE 91D3 06C6'
+          '5E4D F843 FB06 5D7F 7E24  FBA2 EF54 30F0 71E1 B235'
+          '8513 444E 2DA3 6B7C 1659  AF4D 7638 F1FB 2B2B 08C4'
+        - gpg --keyserver hkp://pool.sks-keyservers.net --refresh-keys Swift
+        - gpg --verify swift-4.2.2-RELEASE-ubuntu16.04.tar.gz.sig
         - tar xzf swift-4.2.2-RELEASE-ubuntu16.04.tar.gz
         - export PATH=$(pwd)/swift-4.2.2-RELEASE-ubuntu16.04/usr/bin:"${PATH}"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,23 @@
 sudo: false
 language: swift
 
-services:
-  - mysql
-
 matrix:
   include:
     - os: osx
       osx_image: xcode10.1
+
     - os: linux
       dist: xenial
+      services:
+        - mysql
       before_script:
         - wget https://swift.org/builds/swift-4.2.2-release/ubuntu1604/swift-4.2.2-RELEASE/swift-4.2.2-RELEASE-ubuntu16.04.tar.gz
-        - gpg --keyserver hkp://pool.sks-keyservers.net \
-          --recv-keys \
-          '7463 A81A 4B2E EA1B 551F  FBCF D441 C977 412B 37AD' \
-          '1BE1 E29A 084C B305 F397  D62A 9F59 7F4D 21A5 6D5F' \
-          'A3BA FD35 56A5 9079 C068  94BD 63BC 1CFE 91D3 06C6' \
-          '5E4D F843 FB06 5D7F 7E24  FBA2 EF54 30F0 71E1 B235' \
+        - gpg --keyserver hkp://pool.sks-keyservers.net
+          --recv-keys
+          '7463 A81A 4B2E EA1B 551F  FBCF D441 C977 412B 37AD'
+          '1BE1 E29A 084C B305 F397  D62A 9F59 7F4D 21A5 6D5F'
+          'A3BA FD35 56A5 9079 C068  94BD 63BC 1CFE 91D3 06C6'
+          '5E4D F843 FB06 5D7F 7E24  FBA2 EF54 30F0 71E1 B235'
           '8513 444E 2DA3 6B7C 1659  AF4D 7638 F1FB 2B2B 08C4'
         - gpg --keyserver hkp://pool.sks-keyservers.net --refresh-keys Swift
         - gpg --verify swift-4.2.2-RELEASE-ubuntu16.04.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+sudo: false
+language: swift
+
+services:
+  - mysql
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode10.1
+    - os: linux
+      dist: xenial
+      before_script:
+        - wget https://swift.org/builds/swift-4.2.2-release/ubuntu1604/swift-4.2.2-RELEASE/swift-4.2.2-RELEASE-ubuntu16.04.tar.gz
+        - gpg --keyserver hkp://pool.sks-keyservers.net \
+          --recv-keys \
+          '7463 A81A 4B2E EA1B 551F  FBCF D441 C977 412B 37AD' \
+          '1BE1 E29A 084C B305 F397  D62A 9F59 7F4D 21A5 6D5F' \
+          'A3BA FD35 56A5 9079 C068  94BD 63BC 1CFE 91D3 06C6' \
+          '5E4D F843 FB06 5D7F 7E24  FBA2 EF54 30F0 71E1 B235' \
+          '8513 444E 2DA3 6B7C 1659  AF4D 7638 F1FB 2B2B 08C4'
+        - gpg --keyserver hkp://pool.sks-keyservers.net --refresh-keys Swift
+        - gpg --verify swift-4.2.2-RELEASE-ubuntu16.04.tar.gz
+        - tar xzf swift-4.2.2-RELEASE-ubuntu16.04.tar.gz
+        - export PATH=$(pwd)/swift-4.2.2-RELEASE-ubuntu16.04/usr/bin:"${PATH}"
+
+script:
+  - swift test


### PR DESCRIPTION
Adds an OS X and Linux job for Travis CI. The Linux job includes a MySql server, allowing the tests to run against a test MySql instance. The OS X tests will run in a simulated environment.