### PR TITLE
Add SocketIterator implementation.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "Socket",
+        "repositoryURL": "https://github.com/IBM-Swift/BlueSocket.git",
+        "state": {
+          "branch": null,
+          "revision": "a40b405bdf32bc853307dd5dee8d00636e394013",
+          "version": "1.0.44"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -22,6 +22,13 @@ let package = Package(
       name: "MySqlConnector",
       targets: ["MySqlConnector"]
     ),
+    .library(
+      name: "SocketIterator",
+      targets: ["SocketIterator"]
+    ),
+  ],
+  dependencies: [
+    .package(url: "https://github.com/IBM-Swift/BlueSocket.git", .upToNextMajor(from: "1.0.0")),
   ],
   targets: [
     .target(
@@ -30,13 +37,16 @@ let package = Package(
         "Data+xored",
         "FixedWidthInteger+bytes",
         "LengthEncodedInteger",
-        "LengthEncodedString"
+        "LengthEncodedString",
+        "SocketIterator"
       ]
     ),
     .testTarget(
       name: "MySqlConnectorTests",
       dependencies: ["MySqlConnector"]
     ),
+
+    // Foundation extensions
 
     .target(
       name: "Data+xored",
@@ -55,6 +65,17 @@ let package = Package(
       name: "FixedWidthInteger+bytesTests",
       dependencies: ["FixedWidthInteger+bytes"]
     ),
+
+    // Socket extensions
+
+    .target(
+      name: "SocketIterator",
+      dependencies: [
+        "Socket"
+      ]
+    ),
+
+    // MySql data types
 
     .target(
       name: "LengthEncodedInteger",

--- a/Sources/SocketIterator/SocketIterator.swift
+++ b/Sources/SocketIterator/SocketIterator.swift
@@ -1,0 +1,64 @@
+import Foundation
+import Socket
+
+/**
+ Test environment usage of a server that runs in a separate thread has proven somewhat flaky. A hack-fix makes the
+ socket iterator sleep until data is available to read while in a test environment, but ideally this would be handled by
+ the Socket implementation.
+ */
+private let inTestEnvironment = NSClassFromString("XCTest") != nil
+
+/**
+ Enables iteration over a sequence's data as a continuous stream of bytes, pulling data from the socket as necessary.
+ */
+extension Socket {
+  /**
+   Returns an iterator representation of this socket that reads data as needed.
+
+   Each iterator will pull data from the Socket independently, mutating the Socket's internal data storage as a result.
+   As such, be careful when making multiple iterators not to overlap their use because the resulting behavior is
+   undefined.
+   */
+  public func asIterator() -> AnyIterator<UInt8> {
+    var iterator: Data.Iterator?
+
+    return AnyIterator {
+      if let next = iterator?.next() {
+        return next
+      }
+
+      if !self.isConnected {
+        return nil
+      }
+
+      do {
+        if try !self.testEnvironmentHackFix() {
+          return nil
+        }
+
+        var buffer = Data(capacity: self.readBufferSize)
+        _ = try self.read(into: &buffer)
+        iterator = buffer.makeIterator()
+      } catch {
+        return nil
+      }
+
+      return iterator?.next()
+    }
+  }
+
+  private func testEnvironmentHackFix() throws -> Bool {
+    if inTestEnvironment {
+      var triesRemaining = 1000
+      // Wait until data is available to read.
+      while try !self.isReadableOrWritable(waitForever: true, timeout: 0).readable && triesRemaining > 0 {
+        usleep(1000) // in microseconds
+        triesRemaining -= 1
+      }
+      if triesRemaining == 0 {
+        return false
+      }
+    }
+    return true
+  }
+}


### PR DESCRIPTION
This extension to https://github.com/IBM-Swift/BlueSocket creates a UInt8 iterator for a socket so that data can be read by-for-byte.