### PR TITLE
Fix bug where abandoned connections would never idle.

### DIFF
--- a/Docs/README.md
+++ b/Docs/README.md
@@ -1,0 +1,47 @@
+# MySql Client Documentation
+
+- [Setup](#setup)
+- [Introduction](#introduction)
+
+## Setup
+
+This MySQL client library isn't much use without a MySQL server.
+
+If you don't have one handy, you can spin one up locally by running the included bootstrap command from your terminal:
+
+````
+swift run bootstrap https://dev.mysql.com/get/Downloads/MySQL-8.0/mysql-8.0.20-macos10.15-x86_64.tar.gz
+````
+
+This command will download, extract, and run a MySQL server on your machine. This will configure the server with a passwordless root
+user.
+
+## Introduction
+
+In order to connect to a MySQL server you must create a MySqlClient instance configured with your server's details:
+
+```
+let client = MySqlClient(to: "<#host#>", username: "<#username#>", password: "<#password#>", database: "<#database#>")
+```
+
+Note: if you haven't created a database on your server then you can leave off the database argument for now. You will need to select a
+database later though.
+
+You can then execute queries to your MySQL server through the client instance like so:
+
+```
+do {
+  let response = try client.query("SELECT 'pizza' as food")
+  if case let .Results(iterator) = response {
+    for row in iterator {
+      print(row["food"]) // prints "pizza"
+    }
+  }
+} catch let error {
+  print(error)
+}
+```
+
+try! client.createDatabase(named: databaseName)
+try! client.useDatabase(named: databaseName)
+```

--- a/README.md
+++ b/README.md
@@ -1,10 +1,26 @@
 # MySqlClient
 
-A type-safe MySql client written purely in Swift.
-
-This library is a work-in-progress.
+A pure Swift MySql client with Codable query support.
 
 This is not an official Google product.
+
+- [Features](#features)
+- [Introduction](Docs/)
+- [Supported technologies](#supported-technologies)
+- [License](#license)
+
+## Features
+
+- [x] Decode MySQL query results as Codable objects.
+- [x] Build MySQL queries with Codable objects.
+
+## Supported technologies
+
+- MySQL 5.7
+- iOS 13.0+ / macOS 10.15+
+- Xcode 11.5+
+- Ubuntu 16.04
+- Swift 5
 
 ## License
 

--- a/Sources/MySqlClient/MySqlClient+CommonQueries.swift
+++ b/Sources/MySqlClient/MySqlClient+CommonQueries.swift
@@ -1,0 +1,39 @@
+// Copyright 2020-present the MySqlClient authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extension MySqlClient {
+  /**
+   Creates a new database with the given name.
+   */
+  @discardableResult
+  public func createDatabase(named name: String) throws -> QueryResponse<DictionaryRow> {
+    return try query("CREATE DATABASE \(name)")
+  }
+
+  /**
+   Drops a database with the given name.
+   */
+  @discardableResult
+  public func dropDatabase(named name: String) throws -> QueryResponse<DictionaryRow> {
+    return try query("DROP DATABASE \(name)")
+  }
+
+  /**
+   Changes the selected database.
+   */
+  @discardableResult
+  public func useDatabase(named name: String) throws -> QueryResponse<DictionaryRow> {
+    return try query("USE \(name)")
+  }
+}

--- a/Sources/MySqlClient/MySqlClient.swift
+++ b/Sources/MySqlClient/MySqlClient.swift
@@ -105,7 +105,7 @@ public final class MySqlClient {
   public func query(_ query: String) throws -> QueryResponse<DictionaryRow> {
     return try self.query(query, rowType: DictionaryRow.self)
   }
-  
+
   var connectionPool: [Connection] = []
   let host: String
   let port: Int32

--- a/Sources/MySqlClient/payloads/Query.swift
+++ b/Sources/MySqlClient/payloads/Query.swift
@@ -41,6 +41,8 @@ final class QueryResultDecoder<T: Decodable>: IteratorProtocol {
     if !connection.isIdle {
       // We kill the connection when this instance is released before the results have been fully exhausted, because
       // otherwise this connection would never transition to an idle state.
+      // TODO: Explore sending COM_RESET_CONNECTION instead.
+      // https://dev.mysql.com/doc/internals/en/com-reset-connection.html
       connection.terminate()
     }
   }

--- a/Sources/MySqlClient/payloads/Query.swift
+++ b/Sources/MySqlClient/payloads/Query.swift
@@ -37,6 +37,13 @@ final class QueryResultDecoder<T: Decodable>: IteratorProtocol {
   let connection: Connection
   let columnDefinitions: [ColumnDefinition]
 
+  deinit {
+    if !connection.isIdle {
+      // Terminate any in-progress connections.
+      connection.terminate()
+    }
+  }
+
   init(columnCount: UInt64, connection: Connection) throws {
     self.connection = connection
 

--- a/Sources/MySqlClient/payloads/Query.swift
+++ b/Sources/MySqlClient/payloads/Query.swift
@@ -39,7 +39,8 @@ final class QueryResultDecoder<T: Decodable>: IteratorProtocol {
 
   deinit {
     if !connection.isIdle {
-      // Terminate any in-progress connections.
+      // We kill the connection when this instance is released before the results have been fully exhausted, because
+      // otherwise this connection would never transition to an idle state.
       connection.terminate()
     }
   }

--- a/Tests/MySqlClientTests/ConnectionTests.swift
+++ b/Tests/MySqlClientTests/ConnectionTests.swift
@@ -35,4 +35,95 @@ class ConnectionTests: MySqlClientHarnessTestCase {
     XCTAssertNotNil(connection2)
     XCTAssertTrue(connection1 === connection2)
   }
+
+  // MARK: - Number of connections
+
+  func testOneQueryCreatesOneConnectionButClosesItWhenReleased() throws {
+    // When
+    try client.query("SELECT \"pizza\" AS food")
+
+    // Then
+    XCTAssertEqual(client.connectionPool.count, 1)
+    let idleConnections = client.connectionPool.filter { $0.isIdle }
+    XCTAssertEqual(idleConnections.count, 0)
+    let closedConnections = client.connectionPool.filter { !$0.socket.isConnected }
+    XCTAssertEqual(closedConnections.count, 1)
+  }
+
+  func testTwoQueriesHeldStronglyCreatesTwoConnections() throws {
+    // When
+    let response1 = try client.query("SELECT \"pizza\" AS food")
+    let response2 = try client.query("SELECT \"salmon\" AS food")
+
+    // Then
+    XCTAssertEqual(client.connectionPool.count, 2)
+    let idleConnections = client.connectionPool.filter { $0.isIdle }
+    XCTAssertEqual(idleConnections.count, 0)
+    let closedConnections = client.connectionPool.filter { !$0.socket.isConnected }
+    XCTAssertEqual(closedConnections.count, 0)
+    switch response1 {
+    case .Results:
+      break
+    default:
+      XCTFail("Unhandled case.")
+    }
+    switch response2 {
+    case .Results:
+      break
+    default:
+      XCTFail("Unhandled case.")
+    }
+  }
+
+  func testTwoQueriesReleasedReusesOneConnection() throws {
+    // When
+    try client.query("SELECT \"pizza\" AS food")
+    try client.query("SELECT \"salmon\" AS food")
+
+    // Then
+    XCTAssertEqual(client.connectionPool.count, 1)
+    let closedConnections = client.connectionPool.filter { !$0.socket.isConnected }
+    XCTAssertEqual(closedConnections.count, 1)
+  }
+
+  // MARK: - Connection idling behavior
+
+  func testQueryDoesNotIdleAfterOneIteration() throws {
+    // Given
+    let response = try client.query("SELECT \"pizza\" AS food")
+
+    // When
+    switch response {
+    case .Results(let iterator):
+      XCTAssertNotNil(iterator.next())
+    default:
+      XCTFail("Unhandled case.")
+    }
+
+    // Then
+    let idleConnectionsAfterIteration = client.connectionPool.filter { $0.isIdle }
+    XCTAssertEqual(idleConnectionsAfterIteration.count, 0)
+    let closedConnections = client.connectionPool.filter { !$0.socket.isConnected }
+    XCTAssertEqual(closedConnections.count, 0)
+  }
+
+  func testQueryIdlesAfterIterationExhaustion() throws {
+    // Given
+    let response = try client.query("SELECT \"pizza\" AS food")
+
+    // When
+    switch response {
+    case .Results(let iterator):
+      let results = Array(iterator) // Exhaust the iterator.
+      XCTAssertEqual(results.count, 1)
+    default:
+      XCTFail("Unhandled case.")
+    }
+
+    // Then
+    let idleConnectionsAfterIteration = client.connectionPool.filter { $0.isIdle }
+    XCTAssertEqual(idleConnectionsAfterIteration.count, 1)
+    let closedConnections = client.connectionPool.filter { !$0.socket.isConnected }
+    XCTAssertEqual(closedConnections.count, 0)
+  }
 }

--- a/Tests/MySqlClientTests/DatabaseManagementTests.swift
+++ b/Tests/MySqlClientTests/DatabaseManagementTests.swift
@@ -18,9 +18,12 @@ import XCTest
 
 final class DatabaseManagementTests: MySqlClientHarnessTestCase {
   func testCreatesAndDeletesDatabase() throws {
+    // Given
+    let databaseName = "\(type(of: self))"
+
     // When
-    let creationResponse = try client.query("create database \(type(of: self))")
-    let dropResponse = try client.query("drop database \(type(of: self))")
+    let creationResponse = try client.createDatabase(named: databaseName)
+    let dropResponse = try client.dropDatabase(named: databaseName)
 
     // Then
     switch creationResponse {

--- a/Tests/MySqlClientTests/QueryTests.swift
+++ b/Tests/MySqlClientTests/QueryTests.swift
@@ -22,6 +22,17 @@ struct Variable: Codable {
 }
 
 final class QueryTests: MySqlClientHarnessTestCase {
+  func testFood() throws {
+    // When
+    let response = try client.query("SELECT 'pizza' as food")
+
+    // Then
+    if case let .Results(iterator) = response {
+      let keyValues = Array(iterator)
+      XCTAssertGreaterThan(keyValues.count, 0)
+    }
+  }
+
   func testShowVariablesAsDictionaries() throws {
     // Given
     let query = "SHOW VARIABLES;"

--- a/Tests/MySqlClientTests/TableTests.swift
+++ b/Tests/MySqlClientTests/TableTests.swift
@@ -37,13 +37,15 @@ final class TableTests: MySqlClientHarnessTestCase {
   override func setUp() {
     super.setUp()
 
-    try! client.query("create database \(type(of: self))")
-    try! client.query("use \(type(of: self))")
+    let databaseName = "\(type(of: self))"
+
+    try! client.createDatabase(named: databaseName)
+    try! client.useDatabase(named: databaseName)
     try! client.query("create table \(type(of: self)) (name VARCHAR(20), owner VARCHAR(20), species VARCHAR(20), sex CHAR(1), birth DATE, death DATE)")
   }
 
   override func tearDown() {
-    try! client.query("drop database \(type(of: self))")
+    try! client.dropDatabase(named: "\(type(of: self))")
 
     client = nil
 


### PR DESCRIPTION
This could happen when query responses were deallocated prior to being fully exhausted. When this happened, the connection was no longer exhaustible and could no longer transition to an idle state as a result.

Instead, we now kill connections when the response has not been fully consumed. Killed connections are removed from the connection pool on subsequent queries.